### PR TITLE
Permanently Remove Redux Template Libraries and Banners

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "homepage": "https://github.com/kgjerstad/wp-mail-logging",
     "require": {
         "php": ">=7.1",
-        "redux-framework/redux-framework": "4.3.4"
+        "redux-framework/redux-framework": "4.3.9"
     },
     "require-dev": {
         "bocharsky-bw/arrayzy": "v0.1.1",
@@ -36,6 +36,11 @@
         "psr-4": {
             "No3x\\WPML\\Tests\\": "tests/phpunit/tests",
             "No3x\\WPML\\Tests\\Helper\\": "tests/helper"
+        }
+    },
+    "config": {
+        "allow-plugins": {
+            "composer/installers": true
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -37,10 +37,5 @@
             "No3x\\WPML\\Tests\\": "tests/phpunit/tests",
             "No3x\\WPML\\Tests\\Helper\\": "tests/helper"
         }
-    },
-    "config": {
-        "allow-plugins": {
-            "composer/installers": true
-        }
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e4b88079b6b904c80dbff505133cb3f7",
+    "content-hash": "258ef739e98a451e94c1edc1a102a055",
     "packages": [
         {
             "name": "composer/installers",
@@ -159,16 +159,16 @@
         },
         {
             "name": "redux-framework/redux-framework",
-            "version": "4.3.4",
+            "version": "4.3.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/reduxframework/redux-framework.git",
-                "reference": "f5676033744caa1fe8d98f165901e53090421129"
+                "reference": "e98f1a7f286081b41eca70d6561b567bc39933ac"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/reduxframework/redux-framework/zipball/f5676033744caa1fe8d98f165901e53090421129",
-                "reference": "f5676033744caa1fe8d98f165901e53090421129",
+                "url": "https://api.github.com/repos/reduxframework/redux-framework/zipball/e98f1a7f286081b41eca70d6561b567bc39933ac",
+                "reference": "e98f1a7f286081b41eca70d6561b567bc39933ac",
                 "shasum": ""
             },
             "require": {
@@ -203,10 +203,10 @@
                 "docs": "https://devs.redux.io",
                 "forum": "https://wordpress.org/support/plugin/redux-framework/",
                 "issues": "https://github.com/reduxframework/redux-framework/issues",
-                "source": "https://github.com/reduxframework/redux-framework/tree/4.3.4",
+                "source": "https://github.com/reduxframework/redux-framework/tree/4.3.9",
                 "website": "https://redux.io/"
             },
-            "time": "2021-11-24T02:39:01+00:00"
+            "time": "2022-01-26T19:18:04+00:00"
         }
     ],
     "packages-dev": [
@@ -398,5 +398,5 @@
         "php": ">=7.1"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.2.0"
 }

--- a/src/inc/redux/admin-init.php
+++ b/src/inc/redux/admin-init.php
@@ -1,8 +1,8 @@
 <?php
 
 // Load the embedded Redux Framework
-if ( !class_exists( 'ReduxFramework' ) && file_exists( dirname( __FILE__ ).'/../../../lib/vendor/redux-framework/redux-framework.php' ) ) {
-    require_once dirname(__FILE__) . '/../../../lib/vendor/redux-framework/redux-framework.php';
+if ( !class_exists( 'ReduxFramework' ) && file_exists( dirname( __FILE__ ).'/../../../lib/vendor/redux-framework/redux-core/framework.php' ) ) {
+    require_once dirname(__FILE__) . '/../../../lib/vendor/redux-framework/redux-core/framework.php';
 }
 // Load the theme/plugin options
 if ( file_exists( dirname( __FILE__ ) . '/options-init.php' ) ) {


### PR DESCRIPTION
Hey guys,

Kev Provance, lead Redux dev here.  Thought I'd lend a hand to solve this library issue for y'all, once and for all.

Your composer will now pull down v4.3.9 which contains improvements to prevent the loading of template libs and banners on embedded installs of Redux.

I also changed how the Redux embed is loaded in your project.  Previously the require statement loaded Redux as a plugin when it should've been loaded as an embedded instance (see here for a more detailed explanation, if interested https://devs.redux.io/guides/advanced/embedding-redux.html).  This change will now prevent the loading of template libraries and banners.

Hope this helps y'all out.